### PR TITLE
Allow the gem to be used from a read-only location

### DIFF
--- a/lib/versioner/version.rb
+++ b/lib/versioner/version.rb
@@ -2,5 +2,5 @@
 
 require 'versioner/version_file'
 module Versioner
-  VERSION = VersionFile.new(File.expand_path('../../VERSION', __dir__)).version.freeze
+  VERSION = VersionFile.new(File.expand_path('../../VERSION', __dir__), file_open_options: 'r').version.freeze
 end

--- a/lib/versioner/version_file.rb
+++ b/lib/versioner/version_file.rb
@@ -8,11 +8,11 @@ module Versioner
   end
 
   class VersionFile
-    def initialize(file_name = Versioner.version_file, file_creation_options: nil)
+    def initialize(file_name = Versioner.version_file, file_creation_options: nil, file_open_options: 'r+')
       create_file(file_creation_options) unless file_creation_options.nil? || file_creation_options.empty?
       raise "Version file '#{file_name}' does not exist." unless File.file?(file_name)
 
-      @version_file ||= File.open(file_name, 'r+')
+      @version_file ||= File.open(file_name, file_open_options) 
     end
 
     def self.create(version: '0.1.0-RC.0', path: Versioner.version_file)


### PR DESCRIPTION
Some environments install their gem files and then make everything read-only.
This gem fails when installed in such environments because it tries to open its
own version file in 'r+' mode, just to read the version from it.
This commit allows the read options to be passed in for anyone who wants to use
the gem just for reading a version file without modifying it.